### PR TITLE
mkcertで作成したローカルCAやサーバー証明書を使って、ローカル環境でもHTTPS接続できる様にしました。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# All PEM file
+*.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - app03
     ports:
       - 80:80
+      - 443:443
 
   redis:
     container_name: redis

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,3 +1,4 @@
 # Build HAProxy Container refer https://hub.docker.com/_/haproxy
 FROM haproxy:2.3
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+COPY cert.localhost.pem /usr/local/etc/haproxy/cert.localhost.pem

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -12,6 +12,17 @@ frontend http-in
     bind *:80
     default_backend servers
 
+    # サーバー証明書のパスを指定
+    bind :443 ssl crt /usr/local/etc/haproxy/cert.localhost.pem
+
+    # x-forwarded-for を有効にし、プロトコルとポートもheader にセットする
+    option forwardfor
+    http-request set-header x-forwarded-proto https
+    http-request set-header x-forwarded-port 443
+
+    # httpからのアクセスをhttpsにリダイレクトする
+    redirect scheme https if !{ ssl_fc }
+
 backend servers
     balance roundrobin
 


### PR DESCRIPTION
HAProxyのHTTPS対応